### PR TITLE
Restore automated Jukebox deployments

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,39 @@
+name: Publish Jukebox image
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: jukebox-image-master
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/jukebox
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   jukebox:
     container_name: jukebox
-    build: .
+    image: ghcr.io/alexwohlbruck/jukebox:latest
     restart: unless-stopped
     env_file: .env
     environment:
@@ -10,7 +10,7 @@ services:
     networks:
       - caddy
     labels:
-      com.centurylinklabs.watchtower.enable: "false"
+      com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:8080/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
       interval: 30s

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,16 +17,22 @@ ALLOWED_ORIGINS=https://alex.wohlbruck.dev
 
 The checked-in [.env.example](../.env.example) is a safe template. Never commit the real `.env` file.
 
-## Deploy or update
+## Automatic updates
+
+Pushing to `master` runs [the image-publishing workflow](../.github/workflows/publish-image.yml), which publishes `ghcr.io/alexwohlbruck/jukebox:latest`. Vega's Watchtower checks labeled containers hourly and recreates Jukebox when that tag changes.
+
+The compose service is explicitly labeled `com.centurylinklabs.watchtower.enable=true`. No host port is exposed; the recreated container rejoins `opt_caddy` and Caddy continues to proxy it by name.
+
+## Initial deploy or manual update
 
 ```sh
 cd /opt/jukebox
-docker compose build --quiet
+docker compose pull
 docker compose up -d
 docker compose ps
 ```
 
-The image contains Node.js, `yt-dlp`, and `ffmpeg`, so no host-level media tooling is required.
+Run this once after the GitHub Actions image has been published, or to pull a newly published image without waiting for Watchtower. The image contains Node.js, `yt-dlp`, and `ffmpeg`, so no host-level media tooling is required.
 
 ## Caddy
 
@@ -63,4 +69,5 @@ The expected media type is `audio/mpeg`; `file` should identify MPEG Layer III a
 - `503 Spotify lookup is not configured`: add both Spotify credentials, then recreate the container with `docker compose up -d --force-recreate`.
 - `502 Unable to prepare the requested audio stream`: inspect `docker compose logs jukebox`; YouTube availability and yt-dlp extraction can change independently of the API.
 - TLS errors: verify DNS with `dig +short jukebox.wohlbruck.dev`, then inspect `docker logs caddy` for ACME messages. Caddy's TLS-ALPN validation needs inbound port 443.
-- A stale Docker health status after a rebuild: wait for the healthcheck interval, then run `docker inspect -f '{{.State.Health.Status}}' jukebox`.
+- A stale Docker health status after an update: wait for the healthcheck interval, then run `docker inspect -f '{{.State.Health.Status}}' jukebox`.
+- No automatic update after an hour: check `docker logs watchtower` and confirm `docker inspect jukebox --format '{{index .Config.Labels "com.centurylinklabs.watchtower.enable"}}'` returns `true`.


### PR DESCRIPTION
## Summary

- restore the GHCR publish workflow on top of current master
- configure the Vega Compose service to pull `ghcr.io/alexwohlbruck/jukebox:latest`
- enable Watchtower updates and document the flow

## Verification

- `npm test`