### PR TITLE
Remove audio qualifier from YouTube search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ function cleanStartMs(value) {
 
 function searchQuery({ artist, track }) {
   // The search text is an argument, never a shell command; users cannot inject flags or commands.
-  return `ytsearch1:${artist} - ${track} official audio`;
+  return `ytsearch1:${artist} - ${track}`;
 }
 
 function resolveYouTubeUrl(source) {


### PR DESCRIPTION
Removes the `official audio` suffix from yt-dlp searches.

This fixes `HEALER - Monster`, which previously resolved to King Gizzard’s Gila Monster; the bare query resolves to the HEALER Topic upload.

Verified with `npm test` and the live yt-dlp search.