### PR TITLE
Fix EPIPE crash in /api/tracks/mp3 stream

### DIFF
--- a/app/routes/track.routes.js
+++ b/app/routes/track.routes.js
@@ -30,44 +30,72 @@ router.get('/mp3', function(req, res) {
 		maxResults: 1,
 		type: 'video'
 	}, function(err, data) {
-		if (err) return res.status(err.statusCode).json(err);
-		if (data.items.length == 0) return res.status(404).json({message: "Couldn't find track"});
-		
+		if (err) return res.status(err.statusCode || 500).json(err);
+		if (!data.items || data.items.length == 0) return res.status(404).json({message: "Couldn't find track"});
+
 		var videoId = data.items[0].id.videoId;
 		var url = 'https://www.youtube.com/watch?v='+videoId;
-		
-		var range = '0-';
-		
+
+		// ytdl-core v4 wants {start, end}, not the raw header string -- a string
+		// is silently ignored, so we'd stream the whole file while advertising a
+		// short Content-Length and the client would hang up mid-write.
+		var isPartial = false;
+		var start = 0;
+		var end;
+
 		if (req.headers.range) {
-			range = req.headers.range.replace(/bytes=/, "");
+			var parts = req.headers.range.replace(/bytes=/, "").split("-");
+			var parsedStart = parseInt(parts[0], 10);
+			var parsedEnd = parseInt(parts[1], 10);
+
+			if (!isNaN(parsedStart)) {
+				isPartial = true;
+				start = parsedStart;
+				if (!isNaN(parsedEnd)) end = parsedEnd;
+			}
 		}
-		
+
 		var audio = ytdl(url, {
 			filter: 'audioonly',
-			range: range
+			range: end === undefined ? {start: start} : {start: start, end: end}
 		});
-		
+
+		// The client bailing out (seek, skip, tab close) is routine, not an error.
+		// Without this the pipe keeps writing into a dead socket and the EPIPE
+		// takes the whole process down.
+		var closed = false;
+		function cleanup() {
+			if (closed) return;
+			closed = true;
+			audio.destroy();
+		}
+
+		req.on('aborted', cleanup);
+		res.on('close', cleanup);
+		res.on('error', cleanup);
+
+		audio.on('error', function(err) {
+			console.log('ytdl failed for ' + url + ': ' + err.message);
+			cleanup();
+			if (res.headersSent) return res.destroy();
+			return res.status(502).json({message: "Couldn't stream track"});
+		});
+
 		audio.on('response', function(data) {
-			var totalSize = data.headers['content-length'];
-			
-			var parts = range.split("-");
-			var partialstart = parts[0];
-			var partialend = parts[1];
-			
-			var start = parseInt(partialstart, 10);
-			var end = partialend ? parseInt(partialend, 10) : totalSize - 1;
-			
-			var chunkSize = (end - start) + 1;
-			
-			res.writeHead(200, {
+			if (closed || res.headersSent) return;
+
+			var totalSize = parseInt(data.headers['content-length'], 10);
+			var lastByte = end === undefined ? start + totalSize - 1 : end;
+
+			res.writeHead(isPartial ? 206 : 200, {
 				'Content-Type': 'audio/webm',
-				'Content-Range': 'bytes ' + start + '-' + end + '/' + totalSize,
-				'Content-Length': chunkSize,
+				'Content-Range': 'bytes ' + start + '-' + lastByte + '/' + (start + totalSize),
+				'Content-Length': totalSize,
 				'Content-Disposition': 'inline; filename="'+req.query.track.replace(/[^a-zA-Z0-9 ]/g, "")+'.mp3"',
 				'Accept-Ranges': 'bytes'
 			});
 		});
-		
+
 		audio.pipe(res);
 	});
 });


### PR DESCRIPTION
Jukebox was dying repeatedly on the vega6 homelab node with an unhandled `write EPIPE`, restarting in a loop. Three defects in `/api/tracks/mp3` fed the same crash.

### 1. The pipe had no error handling (the crash itself)

`audio.pipe(res)` had no `error` listener on either end and no cleanup when the client went away. A listener seeking, skipping, or closing the tab kills the socket while ytdl is still pushing bytes — the resulting `EPIPE` had nowhere to go and took the process down.

Now `req`'s `aborted` and `res`'s `close`/`error` events destroy the ytdl stream, and both streams have error handlers. A ytdl failure returns `502` instead of crashing.

### 2. Range requests were silently ignored, which *caused* the disconnects

ytdl-core v4 expects `range: {start, end}`. The code passed the raw header string (`"5000000-"`), which has no `.start`/`.end`, so ytdl dropped the range entirely and streamed **from byte 0** — while the response advertised `Content-Length: totalSize - 5000000`. Every seek meant promising N bytes and sending far more, so the client hung up mid-write. That is a reliable EPIPE generator and fits the tight restart loop in the logs.

### 3. Partial responses returned `200` alongside a `Content-Range` header

Now `206`.

Also guarded `res.status(err.statusCode)` against an undefined status (`res.status(undefined)` throws) and `data.items` being absent.

---

### Two things I could not verify

**The deployed code is not this code.** vega6 logs print `Jukebox listening on port 8080`; `server.js:36` prints `App listening on port 8080!` in every commit on every branch. Supporting that: the crash stack shows Node's `pipe()` error handler firing with a **`Socket`** destination, but the only pipe here targets an Express `ServerResponse`. Whatever runs on that box has a different structure — worth a `git log -1` and `grep -rn "listening on port"` on vega6 before assuming this fix reaches it.

**Not run.** Syntax-checked with `node --check` only. `node_modules` isn't installed locally and the route needs Google/Spotify keys, so the EPIPE was not reproduced or confirmed fixed at runtime.

### Unrelated, worth noting

`ytdl-core@4.11.5` is old and fails often against current YouTube signature/throttling. Those failures now return a clean 502 rather than crashing, but if playback is broken generally that is a separate upgrade (likely `@distube/ytdl-core`).