### PR TITLE
Fix unhandled EPIPE crash in the yt-dlp -> ffmpeg stream pipeline

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,10 +139,24 @@ function streamAsMp3({ artist, track, startMs = 0 }, response, requestedAtMs) {
   const collectError = (chunk) => { errorOutput = `${errorOutput}${chunk}`.slice(-2000); };
   downloader.stderr.on('data', collectError);
   encoder.stderr.on('data', collectError);
+  let stopped = false;
   const stop = () => {
+    stopped = true;
     downloader.kill('SIGTERM');
     encoder.kill('SIGTERM');
   };
+  // A listener hanging up is routine: response 'close' kills ffmpeg, but yt-dlp
+  // is still writing into encoder.stdin. Each stdio pipe is a socket of its own,
+  // and `downloader.on('error')` covers only spawn failures -- so that write
+  // lands on a closed pipe and the unhandled EPIPE takes the process down.
+  const onStreamError = (error) => {
+    if (stopped || error.code === 'EPIPE' || error.code === 'ERR_STREAM_PREMATURE_CLOSE') return;
+    fail(error.message);
+  };
+  downloader.stdout.on('error', onStreamError);
+  encoder.stdin.on('error', onStreamError);
+  encoder.stdout.on('error', onStreamError);
+  response.on('error', stop);
   response.on('close', stop);
   downloader.on('error', (error) => fail(error.message));
   encoder.on('error', (error) => fail(error.message));


### PR DESCRIPTION
Jukebox has been crash-looping on vega6 with an unhandled `write EPIPE`. Container logs confirm it is still happening.

### Cause

In `streamAsMp3`, error handling is attached to the **ChildProcess** objects:

```js
downloader.on('error', (error) => fail(error.message));
encoder.on('error', (error) => fail(error.message));
```

Those only fire for spawn failures (ENOENT and friends). They do not cover the stdio pipes, which are `net.Socket` instances in their own right.

When a listener hangs up, `response.on('close', stop)` SIGTERMs both children. ffmpeg dies and `encoder.stdin` closes while yt-dlp is still producing, so `downloader.stdout.pipe(encoder.stdin)` writes into a closed pipe. The resulting EPIPE has no handler on that socket and takes the whole server down.

The stack trace pins this precisely — it is `pipe()`'s destination-error handler firing with a **`Socket`** destination:

```
Emitted 'error' event on Socket instance at:
    at Socket.onerror (node:internal/streams/readable:1028:14)
```

`streamAsMp3` has exactly two pipes, and only one has a Socket destination:

- `downloader.stdout.pipe(encoder.stdin)` — `encoder.stdin` **is a Socket** ✓
- `encoder.stdout.pipe(response)` — `response` is an Express `ServerResponse` ✗

### Fix

Attach error handlers to the stdio streams themselves. A teardown-time EPIPE is expected and swallowed; anything else still routes to `fail()`. A `stopped` flag suppresses noise from our own SIGTERM, and the existing `close` handlers still surface genuine yt-dlp/ffmpeg failures with their stderr.

### Verification

- `node --test` passes (2/2).
- `node --check` clean.
- **The EPIPE itself was not reproduced.** Three synthetic stand-ins for the yt-dlp/ffmpeg pair failed to trigger it — Node swallowed the post-kill writes. The diagnosis rests on the stack trace uniquely identifying `encoder.stdin` as the pipe destination, not on a runtime repro. Worth watching the container logs after deploy to confirm the loop actually stops.