### PR TITLE
Add bgutil PO token provider for yt-dlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-bookworm-slim
 
 RUN apt-get -o Acquire::Check-Date=false update \
     && apt-get install -y --no-install-recommends ffmpeg python3-pip \
-    && pip3 install --no-cache-dir --break-system-packages yt-dlp \
+    && pip3 install --no-cache-dir --break-system-packages yt-dlp 'bgutil-ytdlp-pot-provider==1.3.1' \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/compose.yml
+++ b/compose.yml
@@ -1,12 +1,27 @@
 services:
+  # Mints YouTube PO tokens for yt-dlp. Pinned to match the plugin version
+  # installed in the image; the two are expected to move together.
+  bgutil-provider:
+    container_name: bgutil-provider
+    image: brainicism/bgutil-ytdlp-pot-provider:1.3.1
+    restart: unless-stopped
+    init: true
+    networks:
+      - caddy
+    labels:
+      com.centurylinklabs.watchtower.enable: "false"
+
   jukebox:
     container_name: jukebox
     image: ghcr.io/alexwohlbruck/jukebox:latest
     restart: unless-stopped
+    depends_on:
+      - bgutil-provider
     env_file: .env
     environment:
       NODE_ENV: production
       PORT: 8080
+      POT_PROVIDER_BASE_URL: http://bgutil-provider:4416
     networks:
       - caddy
     labels:

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,14 @@ import { HttpError, SpotifyClient } from './spotify.js';
 
 const PORT = Number(process.env.PORT || 8080);
 const YTDLP_BIN = process.env.YTDLP_BIN || 'yt-dlp';
+// YouTube rejects unattested requests for the audio formats we want, so yt-dlp
+// mints a PO token per video via the bgutil provider. The plugin defaults to
+// 127.0.0.1, but the provider is its own container -- point it across the
+// compose network. Set POT_PROVIDER_BASE_URL empty to run without a provider.
+const POT_PROVIDER_BASE_URL = process.env.POT_PROVIDER_BASE_URL ?? 'http://bgutil-provider:4416';
+const POT_ARGS = POT_PROVIDER_BASE_URL
+  ? ['--extractor-args', `youtubepot-bgutilhttp:base_url=${POT_PROVIDER_BASE_URL}`]
+  : [];
 const MAX_START_MS = 6 * 60 * 60 * 1000;
 const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',').map((value) => value.trim()).filter(Boolean) || [];
 const spotify = new SpotifyClient({
@@ -104,7 +112,7 @@ function searchQuery({ artist, track }) {
 
 function resolveYouTubeUrl(source) {
   return new Promise((resolve, reject) => {
-    const resolver = spawn(YTDLP_BIN, ['--no-playlist', '--no-warnings', '--skip-download', '--print', '%(webpage_url)s', searchQuery(source)], {
+    const resolver = spawn(YTDLP_BIN, ['--no-playlist', '--no-warnings', ...POT_ARGS, '--skip-download', '--print', '%(webpage_url)s', searchQuery(source)], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let output = '';
@@ -125,7 +133,7 @@ function streamAsMp3({ artist, track, startMs = 0 }, response, requestedAtMs) {
   const elapsedMs = requestedAtMs === undefined ? 0 : Math.max(0, Date.now() - requestedAtMs);
   const liveStartMs = Math.min(MAX_START_MS, startMs + elapsedMs);
   const offset = liveStartMs ? ['--download-sections', `*${(liveStartMs / 1000).toFixed(3)}-inf`] : [];
-  const downloader = spawn(YTDLP_BIN, ['--no-playlist', '--no-warnings', '--format', 'bestaudio/best', ...offset, '--output', '-', search], {
+  const downloader = spawn(YTDLP_BIN, ['--no-playlist', '--no-warnings', ...POT_ARGS, '--format', 'bestaudio/best', ...offset, '--output', '-', search], {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   // This is a live player rather than an archival encoder: start decoding as


### PR DESCRIPTION
Adds the PO token provider from the [yt-dlp PO Token Guide](https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide).

**Read this before merging: it does not restore streaming.** Landing it as groundwork, not a fix.

### Changes

- `Dockerfile` — install the `bgutil-ytdlp-pot-provider` plugin, pinned to `1.3.1`
- `compose.yml` — add the `bgutil-provider` service, pinned to the same `1.3.1`, with watchtower disabled so plugin and server cannot drift apart (the guide requires matching versions)
- `src/index.js` — `POT_PROVIDER_BASE_URL` (default `http://bgutil-provider:4416`) applied to both yt-dlp spawns. The plugin defaults to `127.0.0.1`, which is wrong when the provider is a separate container. Set the var empty to disable.

### It installs correctly

The guide's success signal is present:

```
[youtube] [pot] PO Token Providers: bgutil:http-1.3.1 (external)
```

### It does not fix the 403

Measured on vega6 against the live image:

| case | provider | result |
|---|---|---|
| modern video, `bestaudio` | on | **403** |
| 2005 video, `bestaudio` | on | 252 KB ✓ |
| 2005 video, `bestaudio` | **off** | 252 KB ✓ |

The only working case succeeds with the provider disabled, so the provider is not the active ingredient.

### What the failure actually is

Not music, not DRM, not search — I was wrong on all three in turn. All six results for one search 403'd including plain personal uploads, and a modern non-music video 403'd too. The real split is old-vs-modern: the 2005 video still offers **format 18**, the deprecated muxed mp4 served over ordinary https that predates YouTube's protected delivery. Modern videos have no format 18 and their audio formats 403 on fetch.

So effectively all modern YouTube content is unreachable from this host without authentication. Both egress paths agree on the remedy — the Mullvad exit returned *"Sign in to confirm you're not a bot. Use --cookies-from-browser or --cookies"*, and the residential IP fails at the same boundary later in the flow.

### Why land it anyway

With cookies, the standard working combination is an authenticated `web` client **plus** a GVS PO token, so this is likely a prerequisite for the fix rather than a dead end. Deploying it is behaviour-neutral today: streaming 403s with or without it, and an unreachable provider degrades to a warning rather than an error.