### PR TITLE
Track the yt-dlp nightly channel (fixes all playback)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM node:22-bookworm-slim
 
 RUN apt-get -o Acquire::Check-Date=false update \
     && apt-get install -y --no-install-recommends ffmpeg python3-pip \
-    && pip3 install --no-cache-dir --break-system-packages yt-dlp 'bgutil-ytdlp-pot-provider==1.3.1' \
+    # Nightly, not stable: YouTube changes extraction faster than yt-dlp cuts
+    # releases, and the stable channel lags far enough behind that every modern
+    # video 403s. Rebuild the image when playback starts failing.
+    && pip3 install --no-cache-dir --break-system-packages --pre -U 'yt-dlp[default]' 'bgutil-ytdlp-pot-provider==1.3.1' \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
This is the actual fix for the 403s. One line.

### The problem

Stable `yt-dlp 2026.07.04` — the latest *stable* release, already installed — fails on every modern YouTube video with `HTTP Error 403: Forbidden`. The only content it could fetch was a 2005 upload still carrying the deprecated muxed `format 18`.

Nightly `2026.08.17` downloads the same videos fine.

### Measured on vega6

| configuration | result |
|---|---|
| stable + PO tokens + cookies | 0 bytes |
| stable + PO tokens, no cookies | 0 bytes (403) |
| **nightly alone — no PO tokens, no cookies, no proxy** | **250 KB ✓** |
| nightly + PO tokens | 250 KB ✓ |
| nightly + PO tokens, second track | 250 KB ✓ |

(The `Broken pipe` in those runs is the test harness closing the stream after N bytes — it is the evidence data was flowing.)

### What this retires

Three theories that cost real effort, all wrong:

- **VPN / IP rotation** — Mullvad made it *worse*. The datacenter exit returned "Sign in to confirm you're not a bot" where the residential IP at least got as far as a signed URL.
- **PO tokens** — #32 installs correctly and reports `bgutil:http-1.3.1 (external)`, but the control run shows nightly works with the provider disabled entirely.
- **Cookies** — not merely unnecessary but actively harmful: nightly *with* cookies fails with "The page needs to be reloaded", while nightly without them succeeds.

### Tradeoff

Nightly is unpinned, so builds aren't reproducible and a bad nightly could regress playback. That's the right trade here: YouTube changes extraction faster than yt-dlp cuts stable releases, so pinning guarantees breakage on a schedule while nightly only risks it. Since the image only rebuilds on pushes to master, playback will eventually break again as the pinned-at-build-time nightly ages — a weekly scheduled rebuild in `publish-image.yml` would keep it fresh. Not included here; happy to add it separately.

The PO provider from #32 is left in place. It earns nothing today, but it's already deployed, costs one idle container, and is the most likely thing to be needed again when YouTube tightens next.