### PR TITLE
Rebuild the image weekly to keep yt-dlp current

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,6 +3,11 @@ name: Publish Jukebox image
 on:
   push:
     branches: [master]
+  # yt-dlp is installed from the nightly channel at build time, so the image
+  # ages out on its own: YouTube changes extraction and the baked-in build
+  # starts returning 403 on every video. Rebuild weekly to stay current.
+  schedule:
+    - cron: '17 5 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Follow-up to #33. That PR switched yt-dlp to the nightly channel, which fixed playback — but the nightly is resolved at **build time**, so the image ages out on its own.

Since the image is otherwise only rebuilt on pushes to master, a quiet week is enough for YouTube to change extraction and start returning 403 on every video again. This adds a weekly schedule so the fix doesn't have a shelf life.

```yaml
schedule:
  - cron: '17 5 * * 1'    # Mondays 05:17 UTC
```

Off-the-hour deliberately — GitHub queues scheduled jobs heavily on exact hour boundaries.

### The loop closes automatically

Watchtower runs `--cleanup --interval 3600` on vega6 with no `--label-enable`, so it monitors everything except containers labelled `enable=false`. The labels from #32 land correctly:

- `jukebox` (`enable=true`) → picks up the weekly rebuild within the hour
- `bgutil-provider` (`enable=false`) → stays pinned at 1.3.1, so plugin and server can't drift

No manual deploy needed after this merge.

### Two caveats worth knowing

**GitHub disables scheduled workflows after 60 days of repository inactivity**, and workflow runs themselves don't count as activity — it takes a commit or a manual re-enable. For a repo that gets touched in bursts, this schedule can silently stop. If playback breaks again months from now, check whether the schedule is still enabled before debugging yt-dlp.

**This depends on builds being uncached.** No `cache-from`/`cache-to` is configured, so every run rebuilds from scratch and the `pip install --pre -U` genuinely re-resolves the nightly. If registry caching is added later as a build-speed optimisation, that layer would be reused and the weekly rebuild would silently stop refreshing yt-dlp — the exact failure this PR exists to prevent.